### PR TITLE
Delete nested_trip_c.t.csv

### DIFF
--- a/data/nested_trip_c.t.csv
+++ b/data/nested_trip_c.t.csv
@@ -1,2 +1,0 @@
-"","original_sample","data"
-"1","LL_201703A",


### PR DESCRIPTION
Deleted nested_trip_c.t.csv because csv can't handle nested data, apparently. I'll upload "trip_cleaned.tibble.csv", which has the same information (just not nested).